### PR TITLE
Add a KEYTIMEOUT suggestion for vi users

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -63,6 +63,10 @@ z4h init || return
 # Enable emacs (-e) or vi (-v) keymap.
 bindkey -e
 
+# If you plan on using the Vi keymap, you should lower this value if pressing
+# Escape followed by a motion (like 'h') triggers an unintended binding
+KEYTIMEOUT=40  # hundredths of a second
+
 # Export environment variables.
 export EDITOR=nano
 export GPG_TTY=$TTY


### PR DESCRIPTION
While I was testing, I repeatedly got `z4h-run-help` (Alt+h) by going from Escape to h too quickly.  I don't know a good value to put this to (15 is plenty short for me, but other people may need to use 10 or may have conditions which require a higher number) so I just left a note.