### PR TITLE
support common bin folders being symlinks

### DIFF
--- a/fn/-z4h-init
+++ b/fn/-z4h-init
@@ -460,7 +460,7 @@ if (( _z4h_use[powerlevel10k] )); then
   -z4h-set-term-title-precmd || return
 fi
 
-local dirs=({~/bin,~/.local/bin,~/.cargo/bin,/usr/local/bin}(/N))
+local dirs=({~/bin/,~/.local/bin/,~/.cargo/bin/,/usr/local/bin/}(/N))
 path=(${dirs:|path} $path)
 
 if (( _z4h_use[zsh-autosuggestions] )); then


### PR DESCRIPTION
Noticed that when e.g. `~/bin` is a symlink to a folder, it is not added to `$PATH`, but with trailing slash it is being added to `$PATH` as expected.