### PR TITLE
Debian/Ubuntu package-completions

### DIFF
--- a/fn/-z4h-init
+++ b/fn/-z4h-init
@@ -460,7 +460,9 @@ fpath+=(
   ${^${(M)fpath:#*/$ZSH_VERSION/functions}/%$ZSH_VERSION\/functions/site-functions}(FN)
   ${HOMEBREW_PREFIX:+$HOMEBREW_PREFIX/share/zsh/site-functions}(FN)
   /usr/local/share/zsh/site-functions(FN)
-  /usr/share/zsh/site-functions(FN))
+  /usr/share/zsh/site-functions(FN)
+  /usr/share/zsh/vendor-completions(FN)
+)
 
 # Make it possible to use completion specifications and functions written for bash.
 autoload -Uz bashcompinit


### PR DESCRIPTION
It seems `/usr/share/zsh/vendor-completions` is used by many deb-packages to place related completions.

A few package examples;
❯ dpkg -L systemd pulseaudio curl | grep "vendor-completions\/"
/usr/share/zsh/vendor-completions/_bootctl
/usr/share/zsh/vendor-completions/_busctl
/usr/share/zsh/vendor-completions/_hostnamectl
/usr/share/zsh/vendor-completions/_journalctl
/usr/share/zsh/vendor-completions/_kernel-install
/usr/share/zsh/vendor-completions/_localectl
/usr/share/zsh/vendor-completions/_loginctl
/usr/share/zsh/vendor-completions/_networkctl
/usr/share/zsh/vendor-completions/_resolvectl
/usr/share/zsh/vendor-completions/_sd_hosts_or_user_at_host
/usr/share/zsh/vendor-completions/_sd_outputmodes
/usr/share/zsh/vendor-completions/_sd_unit_files
/usr/share/zsh/vendor-completions/_systemctl
/usr/share/zsh/vendor-completions/_systemd
/usr/share/zsh/vendor-completions/_systemd-analyze
/usr/share/zsh/vendor-completions/_systemd-delta
/usr/share/zsh/vendor-completions/_systemd-inhibit
/usr/share/zsh/vendor-completions/_systemd-run
/usr/share/zsh/vendor-completions/_systemd-tmpfiles
/usr/share/zsh/vendor-completions/_timedatectl
/usr/share/zsh/vendor-completions/_pulseaudio
/usr/share/zsh/vendor-completions/_curl