### PR TITLE
Respect terminal title in tmux

### DIFF
--- a/tmux-16color.conf
+++ b/tmux-16color.conf
@@ -5,3 +5,5 @@ set -sg escape-time 0
 set -g status off
 set -ga terminal-overrides ",*:Tc:smcup@:rmcup@"
 set -g default-terminal "screen"
+set -g set-titles on
+set -g set-titles-string "#T"

--- a/tmux-256color.conf
+++ b/tmux-256color.conf
@@ -5,3 +5,5 @@ set -sg escape-time 0
 set -g status off
 set -ga terminal-overrides ",*:Tc:smcup@:rmcup@"
 set -g default-terminal "tmux-256color"
+set -g set-titles on
+set -g set-titles-string "#T"


### PR DESCRIPTION
This just lets tmux respect the title set via OSC title setting sequence, i.e. pass along the terminal title set by z4h itself