### PR TITLE
Fix: Add missing else in sc/exec-zsh-i

### DIFF
--- a/sc/exec-zsh-i
+++ b/sc/exec-zsh-i
@@ -105,6 +105,8 @@ if '[' '-n' "${ZSH_VERSION-}" ']'; then
     '_z4h_exec_zsh_i' '-i' '-c' "$ZSH_EXECUTION_STRING"
   elif '[' "${+ZSH_SCRIPT}" '=' '1' ']'; then
     '_z4h_exec_zsh_i' '-i' '--' "$ZSH_SCRIPT" "${_z4h_script_argv[@]}"
+  else
+    '_z4h_exec_zsh_i' '-i'
   fi
 else
   '_z4h_exec_zsh_i' '-i'


### PR DESCRIPTION
It seems to me that the else-clause here accidentally got lost in commit 67f713f341b95056ba2f7d6320e22db8bfe2447d. This causes z4h update to fail on systems that do not fulfill the requirement for zsh 5.8 with their default zsh installation.