### PR TITLE
Use command instead of which

### DIFF
--- a/sc/install-tmux
+++ b/sc/install-tmux
@@ -304,7 +304,7 @@ if [ "$num_dirs" = 0 ]; then
   dirs_c="${dirs_c}${lf}  ${_B}(3)${_0} custom directory  ${_Y}<=${_0} manual input required${lf}"
 fi
 
-if ! zsh="$(which zsh)"; then
+if ! zsh="$(command -v zsh)"; then
   >&2 echo "${_R}error${_0}: command not found: ${_B}zsh${_0}"
   exit 1
 fi


### PR DESCRIPTION
When I ssh'd to some server I got this:

```
z4h: installing tmux
/home/maximbaz/.cache/zsh4humans/v5/zsh4humans/sc/install-tmux: line 307: which: command not found
error: command not found: zsh
```

I presume this should be fixed if we use builtin `command` instead of `which`