### PR TITLE
Remove -F from default less args

### DIFF
--- a/fn/-z4h-init
+++ b/fn/-z4h-init
@@ -660,11 +660,10 @@ fi
 #
 #   -i   case-insensitive search unless search string contains uppercase letters
 #   -R   color
-#   -F   exit if there is less than one page of content
 #   -X   keep content on screen after exit
 #   -M   show more info at the bottom prompt line
 #   -x4  tabs are 4 instead of 8
-export LESS='-iRFXMx4'
+export LESS='-iRXMx4'
 
 (( $+commands[less] )) && export PAGER=less
 


### PR DESCRIPTION
Having `-F` bit me because some apps (e.g. `nnn`, `xplr`) rely on the fact that `less` will stay waiting for user to quit, so they display some information (like help, logs) using less - and I was wondering why sometimes I get the window flashing, but no help or logs appear 😅  I don't think we should have `-F` at least by default.

By the way, are you overriding `$SYSTEMD_LESS`? I found that I like to remove `-S` from it, i.e. I change it to `SYSTEMD_LESS=FRXMK` to have wrapping instead of cut off screen. Don't know if you do the same, if it warrants to be in z4h, it may be too personal preference.