### PR TITLE
fix a bug with command-not-found on termux

### DIFF
--- a/fn/-z4h-init
+++ b/fn/-z4h-init
@@ -79,7 +79,7 @@ elif [[ -e /usr/share/doc/pkgfile/command-not-found.zsh ]]; then
 elif [[ -x /usr/libexec/pk-command-not-found && -S /var/run/dbus/system_bus_socket ]]; then
   command_not_found_handler() { /usr/libexec/pk-command-not-found "$@" }
 elif [[ -x /data/data/com.termux/files/usr/libexec/termux/command-not-found ]]; then
-  command_not_found_handler() { /data/data/com.termux/files/usr/libexec/termux/command-not-found "$@" }
+  command_not_found_handler() { /data/data/com.termux/files/usr/libexec/termux/command-not-found "$1" }
 elif [[ -x /run/current-system/sw/bin/command-not-found ]]; then
   command_not_found_handler() { /run/current-system/sw/bin/command-not-found "$@" }
 fi


### PR DESCRIPTION
Termux's `command-not-found` fails when called with multiple arguments.

![Screenshot_20210723-083945_Termux](https://user-images.githubusercontent.com/1180863/126783087-8f9246ca-2a41-4eb4-8324-963924047856.png)
