### PR TITLE
Add docs for prompt-at-bottom

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -14,7 +14,9 @@ zstyle ':z4h:' auto-update-days '28'
 # full-fledged tmux ('system'), or disable features that require tmux ('no').
 zstyle ':z4h:' start-tmux       'integrated'
 # Move prompt to the bottom when zsh starts up so that it's always in the
-# same position. Has no effect if start-tmux is 'no'.
+# same position if start-tmux is 'system' or 'integrated'. Also move prompt
+# to the bottom of screen is cleared with Ctrl-L or Ctrl-Alt-Shift-L
+# regardless of start-tmux setting.
 zstyle ':z4h:' prompt-at-bottom 'yes'
 
 # Keyboard type: 'mac' or 'pc'.


### PR DESCRIPTION
The docs lie about prompt-at-bottom 'yes' having no effect if start-tmux 'no'.

Clearing the screen will change regardless of the start-tmux setting.
```
❯ bindkey |grep -F '^L' # prompt-at-bottom 'yes'
"^L" z4h-clear-screen-soft-bottom
"^[^L" z4h-clear-screen-hard-bottom

❯ bindkey |grep -F '^L' # prompt-at-bottom 'no'
"^L" z4h-clear-screen-soft-top
"^[^L" z4h-clear-screen-hard-top
```
