### PR TITLE
Implements issue #164

### DIFF
--- a/fn/-z4h-zle-line-finish
+++ b/fn/-z4h-zle-line-finish
@@ -12,14 +12,16 @@ if [[ -v _z4h_redraw_fd ]]; then
   unset _z4h_redraw_fd
 fi
 
-if [[ $BUFFER == *' ' ]]; then
-  if [[ -v functions[-z4h-buffer-func] ]]; then
-    builtin unfunction -- -z4h-buffer-func
-  fi
-  if functions[-z4h-buffer-func]="$PREBUFFER$BUFFER" 2>/dev/null &&
-     [[ -v functions[-z4h-buffer-func] ]]; then
-    builtin unfunction -- -z4h-buffer-func
-    BUFFER=${BUFFER%% #}
+if ! zstyle -t :z4h:history preserve-trailing-whitespace; then
+  if [[ $BUFFER == *' ' ]]; then
+    if [[ -v functions[-z4h-buffer-func] ]]; then
+      builtin unfunction -- -z4h-buffer-func
+    fi
+    if functions[-z4h-buffer-func]="$PREBUFFER$BUFFER" 2>/dev/null &&
+       [[ -v functions[-z4h-buffer-func] ]]; then
+      builtin unfunction -- -z4h-buffer-func
+      BUFFER=${BUFFER%% #}
+    fi
   fi
 fi
 


### PR DESCRIPTION
If "zstyle :z4h:history preserve-trailing-whitespace on" is used, then trailing whitespaces will be left. Default is to continue with previous behaviour of eliding whitespaces.

I don't believe I fully understand the logic that will be disabled by this, specifically, why is it unfunctioning -z4h-buffer-func? Hopefully this change doesn't break something else.

Note! This change also needs to be ported to v6. Tell me if you want me to look into that.