### PR TITLE
add numeric argument functionality to all (z)word movement functions resolves #241

### DIFF
--- a/fn/z4h-backward-word
+++ b/fn/z4h-backward-word
@@ -2,16 +2,18 @@
 
 emulate -L zsh -o extended_glob
 local w=${WORDCHARS//[[:space:][:alnum:]]}
-local buf=${LBUFFER%%[[:space:]]#}
-if (( $#buf < 2 )); then
-  buf=
-elif [[ $buf == *[[:space:]]? ]]; then
-  buf[-1]=
-elif [[ $buf[-2,-1] != *[[:alnum:]$w]* ]]; then
-  buf=${buf%%[^[:space:][:alnum:]$w]#}
-else
-  [[ $buf == *[[:alnum:]$w] ]] || buf[-1]=
-  buf=${buf%%[[:alnum:]$w]#}
-fi
-(( CURSOR -= $#LBUFFER - $#buf ))
+repeat ${NUMERIC:-1}; do
+  local buf=${LBUFFER%%[[:space:]]#}
+  if (( $#buf < 2 )); then
+    buf=
+  elif [[ $buf == *[[:space:]]? ]]; then
+    buf[-1]=
+  elif [[ $buf[-2,-1] != *[[:alnum:]$w]* ]]; then
+    buf=${buf%%[^[:space:][:alnum:]$w]#}
+  else
+    [[ $buf == *[[:alnum:]$w] ]] || buf[-1]=
+    buf=${buf%%[[:alnum:]$w]#}
+  fi
+  (( CURSOR -= $#LBUFFER - $#buf ))
+done
 return 0

--- a/fn/z4h-backward-zword
+++ b/fn/z4h-backward-zword
@@ -1,11 +1,13 @@
 #!/usr/bin/env zsh
 
 eval "$_z4h_opt"
-local word buf=$BUFFER
-for word in '' ${(Z:n:)BUFFER}; do
-  local tail=${${buf:$#word}##[[:space:]]#}
-  (( $#tail <= $#RBUFFER )) && break
-  buf=$tail
+repeat ${NUMERIC:-1}; do
+  local word buf=$BUFFER
+  for word in '' ${(Z:n:)BUFFER}; do
+    local tail=${${buf:$#word}##[[:space:]]#}
+    (( $#tail <= $#RBUFFER )) && break
+    buf=$tail
+  done
+  CURSOR=$(($#BUFFER - $#buf))
 done
-CURSOR=$(($#BUFFER - $#buf))
 return 0

--- a/fn/z4h-forward-word
+++ b/fn/z4h-forward-word
@@ -2,16 +2,18 @@
 
 emulate -L zsh -o extended_glob
 local w=${WORDCHARS//[[:space:][:alnum:]]}
-local buf=${RBUFFER##[[:space:]]#}
-if (( $#buf < 2 )); then
-  buf=
-elif [[ $buf == ?[[:space:]]* ]]; then
-  buf[1]=
-elif [[ $buf[1,2] != *[[:alnum:]$w]* ]]; then
-  buf=${buf##[^[:space:][:alnum:]$w]#}
-else
-  [[ $buf == [[:alnum:]$w]* ]] || buf[1]=
-  buf=${buf##[[:alnum:]$w]#}
-fi
-(( CURSOR += $#RBUFFER - $#buf ))
+repeat ${NUMERIC:-1}; do
+  local buf=${RBUFFER##[[:space:]]#}
+  if (( $#buf < 2 )); then
+    buf=
+  elif [[ $buf == ?[[:space:]]* ]]; then
+    buf[1]=
+  elif [[ $buf[1,2] != *[[:alnum:]$w]* ]]; then
+    buf=${buf##[^[:space:][:alnum:]$w]#}
+  else
+    [[ $buf == [[:alnum:]$w]* ]] || buf[1]=
+    buf=${buf##[[:alnum:]$w]#}
+  fi
+  (( CURSOR += $#RBUFFER - $#buf ))
+done
 return 0

--- a/fn/z4h-forward-zword
+++ b/fn/z4h-forward-zword
@@ -1,13 +1,15 @@
 #!/usr/bin/env zsh
 
 eval "$_z4h_opt"
-local word buf=$BUFFER
-for word in ${(Z:n:)BUFFER} ''; do
-  (( $#buf < $#RBUFFER )) && break
-  buf=${${buf##[[:space:]]#}:$#word}
+repeat ${NUMERIC:-1}; do
+  local word buf=$BUFFER
+  for word in ${(Z:n:)BUFFER} ''; do
+    (( $#buf < $#RBUFFER )) && break
+    buf=${${buf##[[:space:]]#}:$#word}
+  done
+  CURSOR=$(($#BUFFER - $#buf))
+  if [[ $KEYMAP == vicmd ]] && (( CURSOR && CURSOR == $#BUFFER )); then
+    (( --CURSOR ))
+  fi
 done
-CURSOR=$(($#BUFFER - $#buf))
-if [[ $KEYMAP == vicmd ]] && (( CURSOR && CURSOR == $#BUFFER )); then
-  (( --CURSOR ))
-fi
 return 0


### PR DESCRIPTION
make z4h-(backward|forward)-move-(z)word functions respect numeric argument (Alt-<num> in emacs mode)

this influences z4h-(backward-)kill-(z)word functions as well