### PR TITLE
Make Ctrl+D exit when prompt has spaces entered

### DIFF
--- a/fn/z4h-eof
+++ b/fn/z4h-eof
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 builtin zle || builtin exit 0
-if [[ "$CONTEXT" == start && -z "$BUFFER" ]]; then
+if [[ "$CONTEXT" == start && -z "${BUFFER// /}" ]]; then
   typeset -g precmd_functions=(z4h-eof)
   builtin zle -w accept-line
 else


### PR DESCRIPTION
Before: open terminal, press Space, press Ctrl+D => Do you wish to see all possibilities? 
After:  open terminal, press Space, press Ctrl+D => terminal exits

It somehow happens occasionally that I have a space typed, and then I press Ctrl+D to exit the shell, but instead I am being prompted to see completion possilibities. 
I am guessing that there is no useful reason not to treat spaces as empty BUFFER, and thus exit the shell even if one or more spaces are currently typed.

What do you think?