### PR TITLE
tips.md: vi mode: fix completion binding

### DIFF
--- a/tips.md
+++ b/tips.md
@@ -620,6 +620,7 @@ use Zsh for Humans in vi mode.
 
 - Select *emacs* when asked by the installer about your preferred keymap.
 - Add `bindkey -v` below `z4h init` in `~/.zshrc`.
+- Fix the completion binding that enabling vi mode breaks: `bindkey '^I' z4h-fzf-complete`
 - Add your own bindings with `bindkey` or `z4h bindkey` below `bindkey -v`.
 
 ## Managing dotfiles


### PR DESCRIPTION
As mentioned in #294, the completions are broken if you enable vi mode. This was a bit difficult to figure out so document it.