### PR TITLE
refactor: make caret optional based on zstyle in comp files

### DIFF
--- a/fn/-z4h-comp-files
+++ b/fn/-z4h-comp-files
@@ -36,8 +36,11 @@
   (( height >= 6 )) || (( height = 6 ))
   (( height <= LINES - 1 )) || (( height = LINES - 1 ))
 
+  local anchor=""
+  zstyle -T :z4h:${WIDGET#z4h-} anchored-match-comp-files && anchor="^"
+
   local opts=(
-    --query=${_z4h_word_prefix:+"^$_z4h_word_prefix"}
+    --query=${_z4h_word_prefix:+"${anchor}$_z4h_word_prefix"}
     --color=hl:201,hl+:201
     --with-nth=2
     --delimiter='\000'

--- a/fn/-z4h-comp-words
+++ b/fn/-z4h-comp-words
@@ -37,8 +37,11 @@
   (( height >= 6 )) || (( height = 6 ))
   (( height <= LINES - 1 )) || (( height = LINES - 1 ))
 
+  local anchor=""
+  zstyle -T :z4h:${WIDGET#z4h-} anchored-match-comp-words && anchor="^"
+
   local opts=(
-    --query=${_z4h_word_prefix:+"^$_z4h_word_prefix"}
+    --query=${_z4h_word_prefix:+"${anchor}$_z4h_word_prefix"}
     --color=hl:201,hl+:201
     --with-nth=2
     --delimiter='\000'


### PR DESCRIPTION
### Description
This PR adds the ability to make the insertion of the anchored match character `^` in completions
optional.

```sh
# disable the insertation of the anchored match character
zstyle ':z4h:fzf-complete' anchored-match-comp-words false
zstyle ':z4h:fzf-complete' anchored-match-comp-files false
```

### Reason
For completing words, I prefer to have it disabled as I frequently  press the `backspace` key
and then enter words to search for a keyword in the description of flags. I
thought adding an option would better serve my use case. The `comp-files` widget was modified only
for completeness sake.
