### PR TITLE
Experimental support for _message content as fzf header

### DIFF
--- a/fn/-z4h-comp-words
+++ b/fn/-z4h-comp-words
@@ -32,7 +32,13 @@
   local -i pct=60
   (( _z4h_can_save_restore_screen )) && pct=100
 
-  local -i height=$(( 100 * ($#indices + 4) < pct * LINES ? $#indices + 4 : pct * LINES / 100 ))
+  local -i header_height=0
+  if [[ $_z4h_comp_msg ]] {
+    local header_lines=(${(f)_z4h_comp_msg})
+    header_height+=$#header_lines
+  }
+
+  local -i height=$(( 100 * ($#indices + 4 + header_height) < pct * LINES ? $#indices + 4 + header_height : pct * LINES / 100 ))
 
   (( height >= 6 )) || (( height = 6 ))
   (( height <= LINES - 1 )) || (( height = LINES - 1 ))

--- a/fn/-z4h-fzf
+++ b/fn/-z4h-fzf
@@ -56,6 +56,10 @@ for k v in ${(kv)keys}; do
   fi
 done
 
+if [[ $_z4h_comp_msg ]]; then
+  flags=(--header=${(%)_z4h_comp_msg} "${flags[@]}")
+fi
+
 local keymap
 printf -v keymap '%s:%s,' ${(kv)keys}
 local out=$("${cmd[@]}" "$@" --bind=${keymap%,} "${flags[@]}")

--- a/fn/-z4h-main-complete
+++ b/fn/-z4h-main-complete
@@ -58,6 +58,9 @@ TRAPQUIT () {
   return 131
 }
 
+function -z4h-clear-message() { unset _z4h_comp_msg }
+compprefuncs+=(-z4h-clear-message)
+
 funcs=("$compprefuncs[@]")
 compprefuncs=()
 for func in "$funcs[@]"; do

--- a/fn/z4h-fzf-complete
+++ b/fn/z4h-fzf-complete
@@ -10,7 +10,7 @@ setopt local_options always_to_end no_auto_list no_auto_menu no_auto_param_keys 
        no_auto_remove_slash no_bash_auto_list no_complete_in_word no_list_ambiguous \
        no_list_beep no_list_packed no_list_rows_first no_menu_complete no_rec_exact
 
-local -ra _z4h_shadow_funcs=(_main_complete _multi_parts _path_files _setup compadd zstyle)
+local -ra _z4h_shadow_funcs=(_main_complete _message _multi_parts _path_files _setup compadd zstyle)
 
 local f
 for f in $_z4h_shadow_funcs; do
@@ -78,6 +78,11 @@ done
     # trial completions on the second. We can achieve this by dropping -M.
     # However, this would not allow us to complete f/b, and we want that.
     compadd -M "r:|${_z4h_sep}=** r:|=*" "$@" - "${_z4h_array[@]}"
+  }
+
+  function _message() {
+    # For now, ignore styles and groups.
+    typeset -g _z4h_comp_msg=${@[-1]}
   }
 
   function _path_files() {


### PR DESCRIPTION
From discussion at https://github.com/romkatv/zsh4humans/issues/352, this draft PR is a place to explore possibilities for retaining messages from `_message` calls so that the user still sees them.