### PR TITLE
Fix docker ctrl-p conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ changes to the file system. Once you exit Zsh, the image is deleted.
 
 - **Alpine Linux**: starts quickly; install additional software with `apk add <package>`
   ```zsh
-  docker run -e TERM -e COLORTERM -e LC_ALL=C.UTF-8 -w /root -it --rm alpine sh -uec '
+  docker run -e TERM -e COLORTERM -e LC_ALL=C.UTF-8 -w /root -it --detach-keys="ctrl-^,ctrl-@" --rm alpine sh -uec '
     apk add zsh curl tmux
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/romkatv/zsh4humans/v5/install)"'
   ```
 - **Ubuntu**: install additional software with `apt install <package>`:
   ```zsh
-  docker run -e TERM -e COLORTERM -w /root -it --rm ubuntu sh -uec '
+  docker run -e TERM -e COLORTERM -w /root -it --detach-keys="ctrl-^,ctrl-@" --rm ubuntu sh -uec '
     apt-get update
     apt-get install -y zsh curl tmux
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/romkatv/zsh4humans/v5/install)"'


### PR DESCRIPTION
By default docker uses 'ctrl-p ctrl-q' to detach container. This conflicts with z4h ctrl-p bind as well as fzf defaults. Unfortunately it can't be set to an empty string, like you can with podman.
Its now 'ctrl-6 ctrl-2'. Which should hopefully avoid its nuisances.