### PR TITLE
refactor(homebrew): Update path for Homebrew's which-formula.rb

### DIFF
--- a/fn/-z4h-command-not-found
+++ b/fn/-z4h-command-not-found
@@ -25,7 +25,7 @@ fi
   fi
   if [[ -v commands[brew] &&
         -n $HOMEBREW_REPOSITORY &&
-        -e $HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-command-not-found/cmd/which-formula.rb ]]; then
+        -e $HOMEBREW_REPOSITORY/Library/Homebrew/cmd/which-formula.rb ]]; then
     if msg="$(command brew which-formula --explain $1 2>/dev/null)" && [[ -n $msg ]]; then
       print -r -- $msg
       return 127

--- a/fn/-z4h-init-zle
+++ b/fn/-z4h-init-zle
@@ -64,7 +64,7 @@ if [[ -v functions[command_not_found_handler] ]]; then
   # Already installed or not needed.
 elif [[ -v commands[brew] &&
         -n $HOMEBREW_REPOSITORY &&
-        -e $HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-command-not-found/cmd/which-formula.rb ||
+        -e $HOMEBREW_REPOSITORY/Library/Homebrew/cmd/which-formula.rb ||
         -x /usr/lib/command-not-found ]]; then
   autoload +X -Uz -- -z4h-command-not-found
   builtin functions -c -- -z4h-command-not-found command_not_found_handler

--- a/fn/-z4h-install-one
+++ b/fn/-z4h-install-one
@@ -36,13 +36,11 @@ else
   zstyle -a :z4h:$1 channel channel || channel=(stable)
   local tmux_cmd='sh -- '${(q)Z4H}/zsh4humans/sc/install-tmux' -d "${Z4H_PACKAGE_DIR}" -q'
   tmux_cmd+=' && print -r -- "$EPOCHREALTIME" >"${Z4H_PACKAGE_DIR}"/stamp'
-  local brew_cmd='command brew tap --quiet homebrew/command-not-found && zf_mkdir -- "${Z4H_PACKAGE_DIR}"'
   case $#channel-$channel[1] in
     2-command) command=$channel[2];;
     1-stable|1-testing)
       case $1 in
         tmux)                       command=$tmux_cmd;;
-        homebrew-command-not-found) command=$brew_cmd;;
         terminfo)                   url=https://github.com/romkatv/terminfo/archive/v1.4.0.tar.gz;;
         *)                          url=https://github.com/zsh4humans/$1/archive/z4h-$channel[1].tar.gz;;
       esac
@@ -58,7 +56,6 @@ else
         zsh-history-substring-search) url=https://github.com/zsh-users/$1/archive/master.tar.gz;;
         terminfo)                     url=https://github.com/romkatv/terminfo/archive/v1.3.0.tar.gz;;
         tmux)                         command=$tmux_cmd;;
-        homebrew-command-not-found)   command=$brew_cmd;;
         *)
           print -Pru2 -- "%F{3}z4h%f: %F{1}internal error%f: unknown package: ${1//\%/%%}"
           return 1

--- a/main.zsh
+++ b/main.zsh
@@ -362,15 +362,9 @@ function -z4h-cmd-init() {
     if [[ -x /usr/lib/systemd/systemd || -x /lib/systemd/systemd ]]; then
       _z4h_install_queue+=(systemd)
     fi
-    local brew
-    if [[ -n $HOMEBREW_REPOSITORY(#qNU) &&
-          ! -e $HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-command-not-found/cmd/which-formula.rb &&
-          -v commands[brew] ]]; then
-      brew=homebrew-command-not-found
-    fi
     _z4h_install_queue+=(
       zsh-history-substring-search zsh-autosuggestions zsh-completions
-      zsh-syntax-highlighting terminfo fzf $brew powerlevel10k)
+      zsh-syntax-highlighting terminfo fzf powerlevel10k)
     (( install_tmux )) && _z4h_install_queue+=(tmux)
     if ! -z4h-install-many; then
       [[ -e $Z4H/.updating ]] || -z4h-error-command init


### PR DESCRIPTION
## description

after updating homebrew and opening a new terminal, an error occured:

```bash
z4h: installing homebrew-command-not-found
Error: homebrew/command-not-found was deprecated. This tap is now empty and all its contents were either deleted or migrated.

z4h: init failed

See error messages above to identify the culprit.

Edit Zsh configuration:

  vi ~/.dotfiles/zsh/.zshrc

Retry Zsh initialization:

  exec zsh

If nothing helps and you are about to give up:

  # nuke the entire site from orbit
  sudo rm -rf -- ~/.cache/zsh4humans/v5

Give up and start over:

  sh -c "$(curl -fsSL https://raw.githubusercontent.com/romkatv/zsh4humans/v5/install)"
```

### related

Homebrew deprecated the `Homebrew/homebrew-command-not-found` tap

- https://github.com/Homebrew/brew/pull/20730

---

PS: Please close the report if the suggested fix is incomplete, and you want to
apply your own solution.
