### PR TITLE
fix: zparseopts error in zsh dev version

### DIFF
--- a/fn/-z4h-cmd-bindkey
+++ b/fn/-z4h-cmd-bindkey
@@ -2,7 +2,7 @@
 
 eval "$_z4h_opt"
 
-zparseopts -D -F -- || return '_z4h_err()'
+zparseopts -D -F -- '' || return '_z4h_err()'
 
 if (( ARGC < 2 )); then
   -z4h-help-bindkey >&2

--- a/fn/-z4h-cmd-compile
+++ b/fn/-z4h-cmd-compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 local file
-zparseopts -D -F -- || return '_z4h_err()'
+zparseopts -D -F -- '' || return '_z4h_err()'
 emulate zsh -o extended_glob -c 'local files=(${^@}(N))'
 builtin set --
 for file in "${files[@]}"; do


### PR DESCRIPTION
zsh commit 88d51a24[^1] made zparseopts stricter: when no option specs are
expected, the builtin now requires an explicit '' or '-' after --.

### to reproduce

1. compile latest zsh-dev binary
2. run

```bash
zsh -fc 'zparseopts -D -F -- || echo fail'
zsh:zparseopts:1: missing option descriptions
fail
```

[^1]: https://github.com/zsh-users/zsh/commit/88d51a2

**EDIT:** correct GitHub link
